### PR TITLE
remove useless wrapped

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,12 +1,11 @@
 (library
- (name extlib)
+ (name extLib)
  (public_name extlib)
  (modules :standard \ configure install uChar uTF8)
  (flags :standard -w -3-6-9-27-32-33-35-39-50)
  (preprocess
   (action
-   (run %{bin:cppo} %{read-lines:compat-level} %{input-file})))
- (wrapped false))
+   (run %{bin:cppo} %{read-lines:compat-level} %{input-file}))))
 
 (rule
  (targets compat-level)


### PR DESCRIPTION
their is already a file named `extLib.ml` that play the role of including all other files.